### PR TITLE
Add stock chart website with GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy-stock-chart.yml
+++ b/.github/workflows/deploy-stock-chart.yml
@@ -1,0 +1,41 @@
+name: Deploy Stock Chart Website
+
+on:
+  push:
+    branches: [claude/stock-chart-website-x1iujo, main]
+    paths:
+      - 'stock-chart-website/**'
+      - '.github/workflows/deploy-stock-chart.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: stock-chart-website
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy-stock-chart.yml
+++ b/.github/workflows/deploy-stock-chart.yml
@@ -9,33 +9,18 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-concurrency:
-  group: pages
-  cancel-in-progress: false
+  contents: write
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: stock-chart-website
-
       - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: stock-chart-website
+          branch: gh-pages
+          clean: true

--- a/stock-chart-website/css/style.css
+++ b/stock-chart-website/css/style.css
@@ -1,0 +1,304 @@
+/* ===== Reset & Base ===== */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root {
+  --bg: #0d1117;
+  --surface: #161b22;
+  --surface2: #21262d;
+  --border: #30363d;
+  --text: #e6edf3;
+  --text-muted: #8b949e;
+  --accent: #58a6ff;
+  --green: #3fb950;
+  --red: #f85149;
+  --yellow: #d29922;
+  --radius: 10px;
+  --shadow: 0 4px 24px rgba(0,0,0,.4);
+}
+
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans TC', sans-serif;
+  line-height: 1.6;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+/* ===== Header ===== */
+.header {
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+.header-inner {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+  height: 60px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.logo { font-size: 1.25rem; font-weight: 700; letter-spacing: .5px; }
+.nav { display: flex; gap: .5rem; }
+.nav-link {
+  color: var(--text-muted);
+  text-decoration: none;
+  padding: .35rem .75rem;
+  border-radius: 6px;
+  font-size: .9rem;
+  transition: color .2s, background .2s;
+}
+.nav-link:hover, .nav-link.active { color: var(--text); background: var(--surface2); }
+
+/* ===== Main ===== */
+.main {
+  flex: 1;
+  max-width: 1100px;
+  margin: 0 auto;
+  width: 100%;
+  padding: 2rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+/* ===== Search ===== */
+.search-section {}
+.search-box {
+  display: flex;
+  gap: .75rem;
+  margin-bottom: 1rem;
+}
+.search-input {
+  flex: 1;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text);
+  font-size: 1rem;
+  padding: .75rem 1rem;
+  outline: none;
+  transition: border-color .2s;
+}
+.search-input::placeholder { color: var(--text-muted); }
+.search-input:focus { border-color: var(--accent); }
+.search-btn {
+  background: var(--accent);
+  border: none;
+  border-radius: var(--radius);
+  color: #0d1117;
+  cursor: pointer;
+  font-size: 1rem;
+  font-weight: 600;
+  padding: .75rem 1.5rem;
+  transition: opacity .2s;
+  white-space: nowrap;
+}
+.search-btn:hover { opacity: .85; }
+
+.quick-picks { display: flex; flex-wrap: wrap; align-items: center; gap: .5rem; }
+.quick-label { color: var(--text-muted); font-size: .85rem; }
+.quick-btn {
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text);
+  cursor: pointer;
+  font-size: .85rem;
+  padding: .3rem .7rem;
+  transition: border-color .2s, background .2s;
+}
+.quick-btn:hover { border-color: var(--accent); background: var(--surface); }
+
+/* ===== Info Card ===== */
+.info-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1.5rem;
+  box-shadow: var(--shadow);
+}
+.info-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 1.25rem;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+.stock-name { font-size: 1.5rem; font-weight: 700; }
+.stock-symbol { color: var(--text-muted); font-size: .95rem; }
+.price-block { text-align: right; }
+.price { font-size: 2rem; font-weight: 700; }
+.price-change { font-size: 1rem; font-weight: 600; }
+.price-change.up { color: var(--green); }
+.price-change.down { color: var(--red); }
+
+.info-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
+  gap: .75rem;
+}
+.info-item {
+  background: var(--surface2);
+  border-radius: 8px;
+  padding: .6rem .9rem;
+}
+.info-label { display: block; color: var(--text-muted); font-size: .8rem; margin-bottom: .1rem; }
+.info-value { font-size: .95rem; font-weight: 600; }
+
+/* ===== Chart ===== */
+.chart-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1.25rem;
+  box-shadow: var(--shadow);
+}
+.chart-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: .75rem;
+  margin-bottom: 1rem;
+}
+.period-btns, .chart-type-btns { display: flex; gap: .35rem; flex-wrap: wrap; }
+.period-btn, .type-btn {
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: .85rem;
+  padding: .3rem .65rem;
+  transition: all .2s;
+}
+.period-btn:hover, .type-btn:hover { color: var(--text); border-color: var(--accent); }
+.period-btn.active, .type-btn.active {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #0d1117;
+  font-weight: 600;
+}
+
+.chart-wrapper { position: relative; height: 380px; }
+#stockChart { width: 100% !important; height: 100% !important; }
+
+.chart-loading {
+  display: none;
+  position: absolute;
+  inset: 0;
+  background: rgba(22,27,34,.85);
+  border-radius: 8px;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: .75rem;
+  font-size: .9rem;
+  color: var(--text-muted);
+}
+.chart-loading.show { display: flex; }
+.spinner {
+  width: 36px; height: 36px;
+  border: 3px solid var(--border);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: spin .8s linear infinite;
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+
+/* ===== Watchlist ===== */
+.watchlist-section {}
+.section-title { font-size: 1.15rem; font-weight: 700; margin-bottom: .75rem; }
+.watchlist-actions { margin-bottom: .75rem; }
+.add-btn {
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--accent);
+  cursor: pointer;
+  font-size: .9rem;
+  font-weight: 600;
+  padding: .45rem 1rem;
+  transition: background .2s, border-color .2s;
+}
+.add-btn:hover { background: var(--surface); border-color: var(--accent); }
+.watchlist-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 1rem;
+}
+.empty-hint { color: var(--text-muted); font-size: .9rem; }
+.watch-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1rem;
+  cursor: pointer;
+  transition: border-color .2s, transform .15s;
+  position: relative;
+}
+.watch-card:hover { border-color: var(--accent); transform: translateY(-2px); }
+.watch-card-symbol { font-weight: 700; font-size: 1.05rem; margin-bottom: .25rem; }
+.watch-card-price { font-size: 1.1rem; }
+.watch-card-change { font-size: .85rem; font-weight: 600; }
+.watch-card-change.up { color: var(--green); }
+.watch-card-change.down { color: var(--red); }
+.watch-remove {
+  position: absolute;
+  top: .5rem; right: .6rem;
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+  opacity: .5;
+  transition: opacity .2s;
+}
+.watch-remove:hover { opacity: 1; color: var(--red); }
+
+/* ===== Footer ===== */
+.footer {
+  border-top: 1px solid var(--border);
+  padding: 1.25rem 1.5rem;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: .85rem;
+}
+.footer a { color: var(--accent); text-decoration: none; }
+.footer a:hover { text-decoration: underline; }
+
+/* ===== Toast ===== */
+.toast {
+  position: fixed;
+  bottom: 1.5rem;
+  left: 50%;
+  transform: translateX(-50%) translateY(80px);
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--text);
+  padding: .65rem 1.25rem;
+  font-size: .9rem;
+  box-shadow: var(--shadow);
+  transition: transform .3s ease;
+  z-index: 999;
+  pointer-events: none;
+  white-space: nowrap;
+}
+.toast.show { transform: translateX(-50%) translateY(0); }
+
+/* ===== Responsive ===== */
+@media (max-width: 600px) {
+  .chart-wrapper { height: 260px; }
+  .price { font-size: 1.5rem; }
+  .stock-name { font-size: 1.2rem; }
+  .info-grid { grid-template-columns: repeat(2, 1fr); }
+}

--- a/stock-chart-website/css/style.css
+++ b/stock-chart-website/css/style.css
@@ -11,7 +11,6 @@
   --accent: #58a6ff;
   --green: #3fb950;
   --red: #f85149;
-  --yellow: #d29922;
   --radius: 10px;
   --shadow: 0 4px 24px rgba(0,0,0,.4);
 }
@@ -55,6 +54,43 @@ body {
 }
 .nav-link:hover, .nav-link.active { color: var(--text); background: var(--surface2); }
 
+/* ===== Ticker Bar ===== */
+.ticker-bar {
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  padding: .45rem 1.5rem;
+  overflow-x: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
+}
+.ticker-bar::-webkit-scrollbar { height: 3px; }
+.ticker-bar::-webkit-scrollbar-track { background: transparent; }
+.ticker-bar::-webkit-scrollbar-thumb { background: var(--border); border-radius: 2px; }
+
+.ticker-inner {
+  display: flex;
+  gap: 1.75rem;
+  align-items: center;
+  min-width: max-content;
+}
+.ticker-loading { color: var(--text-muted); font-size: .82rem; }
+.ticker-item {
+  display: flex;
+  align-items: center;
+  gap: .55rem;
+  cursor: pointer;
+  padding: .2rem .4rem;
+  border-radius: 6px;
+  transition: background .2s;
+  white-space: nowrap;
+}
+.ticker-item:hover { background: var(--surface2); }
+.ticker-name { color: var(--text-muted); font-size: .78rem; }
+.ticker-price { font-size: .88rem; font-weight: 600; }
+.ticker-change { font-size: .78rem; font-weight: 600; }
+.ticker-change.up { color: var(--green); }
+.ticker-change.down { color: var(--red); }
+
 /* ===== Main ===== */
 .main {
   flex: 1;
@@ -68,7 +104,6 @@ body {
 }
 
 /* ===== Search ===== */
-.search-section {}
 .search-box {
   display: flex;
   gap: .75rem;
@@ -98,8 +133,10 @@ body {
   padding: .75rem 1.5rem;
   transition: opacity .2s;
   white-space: nowrap;
+  min-width: 90px;
 }
-.search-btn:hover { opacity: .85; }
+.search-btn:hover:not(:disabled) { opacity: .85; }
+.search-btn:disabled { opacity: .55; cursor: not-allowed; }
 
 .quick-picks { display: flex; flex-wrap: wrap; align-items: center; gap: .5rem; }
 .quick-label { color: var(--text-muted); font-size: .85rem; }
@@ -168,8 +205,8 @@ body {
   gap: .75rem;
   margin-bottom: 1rem;
 }
-.period-btns, .chart-type-btns { display: flex; gap: .35rem; flex-wrap: wrap; }
-.period-btn, .type-btn {
+.period-btns { display: flex; gap: .35rem; flex-wrap: wrap; }
+.period-btn {
   background: transparent;
   border: 1px solid var(--border);
   border-radius: 6px;
@@ -179,14 +216,64 @@ body {
   padding: .3rem .65rem;
   transition: all .2s;
 }
-.period-btn:hover, .type-btn:hover { color: var(--text); border-color: var(--accent); }
-.period-btn.active, .type-btn.active {
+.period-btn:hover { color: var(--text); border-color: var(--accent); }
+.period-btn.active {
   background: var(--accent);
   border-color: var(--accent);
   color: #0d1117;
   font-weight: 600;
 }
 
+/* Chart right controls */
+.chart-controls {
+  display: flex;
+  align-items: center;
+  gap: .6rem;
+}
+.ma-btns { display: flex; gap: .35rem; }
+.ma-btn {
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: .8rem;
+  padding: .28rem .6rem;
+  transition: all .2s;
+  display: flex;
+  align-items: center;
+  gap: .3rem;
+}
+.ma-btn::before {
+  content: '';
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--ma-color, #8b949e);
+  flex-shrink: 0;
+}
+.ma-btn:hover { color: var(--text); border-color: var(--ma-color, var(--accent)); }
+.ma-btn.active {
+  border-color: var(--ma-color, var(--accent));
+  color: var(--ma-color, var(--text));
+  background: rgba(255,255,255,.07);
+}
+
+.download-btn {
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: .8rem;
+  padding: .28rem .65rem;
+  transition: all .2s;
+  white-space: nowrap;
+}
+.download-btn:hover { color: var(--text); border-color: var(--accent); }
+
+/* Chart wrapper */
 .chart-wrapper { position: relative; height: 380px; }
 #stockChart { width: 100% !important; height: 100% !important; }
 
@@ -213,8 +300,35 @@ body {
 }
 @keyframes spin { to { transform: rotate(360deg); } }
 
+.chart-error {
+  position: absolute;
+  inset: 0;
+  background: rgba(22,27,34,.9);
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: .85rem;
+  color: var(--text-muted);
+  font-size: .9rem;
+  text-align: center;
+  padding: 1rem;
+}
+.retry-btn {
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--accent);
+  cursor: pointer;
+  font-size: .9rem;
+  font-weight: 600;
+  padding: .45rem 1.2rem;
+  transition: background .2s, border-color .2s;
+}
+.retry-btn:hover { background: var(--surface); border-color: var(--accent); }
+
 /* ===== Watchlist ===== */
-.watchlist-section {}
 .section-title { font-size: 1.15rem; font-weight: 700; margin-bottom: .75rem; }
 .watchlist-actions { margin-bottom: .75rem; }
 .add-btn {
@@ -296,9 +410,11 @@ body {
 .toast.show { transform: translateX(-50%) translateY(0); }
 
 /* ===== Responsive ===== */
-@media (max-width: 600px) {
+@media (max-width: 700px) {
   .chart-wrapper { height: 260px; }
   .price { font-size: 1.5rem; }
   .stock-name { font-size: 1.2rem; }
   .info-grid { grid-template-columns: repeat(2, 1fr); }
+  .chart-toolbar { flex-direction: column; align-items: flex-start; }
+  .chart-controls { flex-wrap: wrap; }
 }

--- a/stock-chart-website/index.html
+++ b/stock-chart-website/index.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html lang="zh-TW">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>股票圖表查詢</title>
+  <link rel="stylesheet" href="css/style.css" />
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@3.0.0/dist/chartjs-adapter-date-fns.bundle.min.js"></script>
+</head>
+<body>
+  <header class="header">
+    <div class="header-inner">
+      <div class="logo">📈 股票圖表</div>
+      <nav class="nav">
+        <a href="#" class="nav-link active">圖表</a>
+        <a href="#watchlist" class="nav-link">自選清單</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="main">
+    <!-- 搜尋區 -->
+    <section class="search-section">
+      <div class="search-box">
+        <input
+          type="text"
+          id="symbolInput"
+          class="search-input"
+          placeholder="輸入股票代號（如 AAPL, TSLA, 2330.TW）"
+          autocomplete="off"
+        />
+        <button id="searchBtn" class="search-btn">查詢</button>
+      </div>
+      <div class="quick-picks">
+        <span class="quick-label">熱門：</span>
+        <button class="quick-btn" data-symbol="AAPL">AAPL</button>
+        <button class="quick-btn" data-symbol="TSLA">TSLA</button>
+        <button class="quick-btn" data-symbol="NVDA">NVDA</button>
+        <button class="quick-btn" data-symbol="MSFT">MSFT</button>
+        <button class="quick-btn" data-symbol="2330.TW">台積電</button>
+        <button class="quick-btn" data-symbol="0050.TW">元大台灣50</button>
+      </div>
+    </section>
+
+    <!-- 股票資訊卡 -->
+    <section class="stock-info" id="stockInfo" style="display:none;">
+      <div class="info-card">
+        <div class="info-header">
+          <div>
+            <h1 class="stock-name" id="stockName">--</h1>
+            <span class="stock-symbol" id="stockSymbol">--</span>
+          </div>
+          <div class="price-block">
+            <div class="price" id="stockPrice">--</div>
+            <div class="price-change" id="priceChange">--</div>
+          </div>
+        </div>
+        <div class="info-grid">
+          <div class="info-item">
+            <span class="info-label">開盤</span>
+            <span class="info-value" id="infoOpen">--</span>
+          </div>
+          <div class="info-item">
+            <span class="info-label">最高</span>
+            <span class="info-value" id="infoHigh">--</span>
+          </div>
+          <div class="info-item">
+            <span class="info-label">最低</span>
+            <span class="info-value" id="infoLow">--</span>
+          </div>
+          <div class="info-item">
+            <span class="info-label">成交量</span>
+            <span class="info-value" id="infoVolume">--</span>
+          </div>
+          <div class="info-item">
+            <span class="info-label">52週高</span>
+            <span class="info-value" id="info52High">--</span>
+          </div>
+          <div class="info-item">
+            <span class="info-label">52週低</span>
+            <span class="info-value" id="info52Low">--</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- 圖表區 -->
+    <section class="chart-section" id="chartSection" style="display:none;">
+      <div class="chart-card">
+        <div class="chart-toolbar">
+          <div class="period-btns">
+            <button class="period-btn" data-period="1d">1日</button>
+            <button class="period-btn" data-period="5d">5日</button>
+            <button class="period-btn active" data-period="1mo">1月</button>
+            <button class="period-btn" data-period="3mo">3月</button>
+            <button class="period-btn" data-period="6mo">6月</button>
+            <button class="period-btn" data-period="1y">1年</button>
+            <button class="period-btn" data-period="5y">5年</button>
+          </div>
+          <div class="chart-type-btns">
+            <button class="type-btn active" data-type="line" title="折線圖">折線</button>
+            <button class="type-btn" data-type="candle" title="K線圖">K線</button>
+          </div>
+        </div>
+        <div class="chart-wrapper">
+          <canvas id="stockChart"></canvas>
+          <div class="chart-loading" id="chartLoading">
+            <div class="spinner"></div>
+            <p>載入中…</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- 自選清單 -->
+    <section class="watchlist-section" id="watchlist">
+      <h2 class="section-title">自選清單</h2>
+      <div class="watchlist-actions">
+        <button id="addToWatchlist" class="add-btn" style="display:none;">加入自選</button>
+      </div>
+      <div class="watchlist-grid" id="watchlistGrid">
+        <p class="empty-hint">尚無自選股票，搜尋後點擊「加入自選」新增。</p>
+      </div>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <p>資料來源：Yahoo Finance（非即時，僅供參考）&nbsp;·&nbsp;
+      <a href="https://github.com/flowerhere/agents" target="_blank">GitHub</a>
+    </p>
+  </footer>
+
+  <div class="toast" id="toast"></div>
+
+  <script src="js/app.js"></script>
+</body>
+</html>

--- a/stock-chart-website/index.html
+++ b/stock-chart-website/index.html
@@ -19,6 +19,13 @@
     </div>
   </header>
 
+  <!-- 大盤指數跑馬燈 -->
+  <div class="ticker-bar">
+    <div class="ticker-inner" id="tickerInner">
+      <span class="ticker-loading">載入大盤資料…</span>
+    </div>
+  </div>
+
   <main class="main">
     <!-- 搜尋區 -->
     <section class="search-section">
@@ -98,9 +105,13 @@
             <button class="period-btn" data-period="1y">1年</button>
             <button class="period-btn" data-period="5y">5年</button>
           </div>
-          <div class="chart-type-btns">
-            <button class="type-btn active" data-type="line" title="折線圖">折線</button>
-            <button class="type-btn" data-type="candle" title="K線圖">K線</button>
+          <div class="chart-controls">
+            <div class="ma-btns">
+              <button class="ma-btn" data-ma="5"  style="--ma-color:#f0883e" title="5日均線">MA5</button>
+              <button class="ma-btn" data-ma="20" style="--ma-color:#79c0ff" title="20日均線">MA20</button>
+              <button class="ma-btn" data-ma="60" style="--ma-color:#bc8cff" title="60日均線">MA60</button>
+            </div>
+            <button class="download-btn" id="downloadChart" title="下載圖表 PNG">↓ PNG</button>
           </div>
         </div>
         <div class="chart-wrapper">
@@ -108,6 +119,10 @@
           <div class="chart-loading" id="chartLoading">
             <div class="spinner"></div>
             <p>載入中…</p>
+          </div>
+          <div class="chart-error" id="chartError" style="display:none;">
+            <p>⚠️ 無法載入資料，請確認股票代號或稍後再試。</p>
+            <button class="retry-btn" id="retryBtn">重試</button>
           </div>
         </div>
       </div>
@@ -132,7 +147,6 @@
   </footer>
 
   <div class="toast" id="toast"></div>
-
   <script src="js/app.js"></script>
 </body>
 </html>

--- a/stock-chart-website/js/app.js
+++ b/stock-chart-website/js/app.js
@@ -1,0 +1,379 @@
+/* ===================================================
+   Stock Chart App
+   Uses Yahoo Finance proxy via allorigins.win to
+   avoid CORS issues on GitHub Pages (static hosting).
+   Data is delayed / non-realtime — for reference only.
+   =================================================== */
+
+const PROXY = 'https://api.allorigins.win/get?url=';
+
+/* ── DOM refs ── */
+const symbolInput   = document.getElementById('symbolInput');
+const searchBtn     = document.getElementById('searchBtn');
+const stockInfo     = document.getElementById('stockInfo');
+const chartSection  = document.getElementById('chartSection');
+const chartLoading  = document.getElementById('chartLoading');
+const addWatchBtn   = document.getElementById('addToWatchlist');
+const watchGrid     = document.getElementById('watchlistGrid');
+const toastEl       = document.getElementById('toast');
+
+let chartInstance   = null;
+let currentSymbol   = '';
+let currentPeriod   = '1mo';
+let currentType     = 'line';
+
+/* ── Quick picks ── */
+document.querySelectorAll('.quick-btn').forEach(btn => {
+  btn.addEventListener('click', () => search(btn.dataset.symbol));
+});
+
+/* ── Period buttons ── */
+document.querySelectorAll('.period-btn').forEach(btn => {
+  btn.addEventListener('click', () => {
+    document.querySelectorAll('.period-btn').forEach(b => b.classList.remove('active'));
+    btn.classList.add('active');
+    currentPeriod = btn.dataset.period;
+    if (currentSymbol) loadChart(currentSymbol, currentPeriod);
+  });
+});
+
+/* ── Chart type buttons ── */
+document.querySelectorAll('.type-btn').forEach(btn => {
+  btn.addEventListener('click', () => {
+    document.querySelectorAll('.type-btn').forEach(b => b.classList.remove('active'));
+    btn.classList.add('active');
+    currentType = btn.dataset.type;
+    if (currentSymbol) loadChart(currentSymbol, currentPeriod);
+  });
+});
+
+/* ── Search ── */
+searchBtn.addEventListener('click', () => search(symbolInput.value.trim()));
+symbolInput.addEventListener('keydown', e => {
+  if (e.key === 'Enter') search(symbolInput.value.trim());
+});
+
+async function search(symbol) {
+  if (!symbol) return;
+  symbol = symbol.toUpperCase();
+  symbolInput.value = symbol;
+  currentSymbol = symbol;
+
+  stockInfo.style.display = 'none';
+  chartSection.style.display = 'none';
+  addWatchBtn.style.display = 'none';
+
+  await Promise.all([loadQuote(symbol), loadChart(symbol, currentPeriod)]);
+
+  stockInfo.style.display = '';
+  chartSection.style.display = '';
+  addWatchBtn.style.display = '';
+}
+
+/* ── Yahoo Finance helpers ── */
+function yahooUrl(endpoint) {
+  return PROXY + encodeURIComponent('https://query1.finance.yahoo.com/v8/finance/' + endpoint);
+}
+
+function periodToRange(period) {
+  const map = {
+    '1d':  { range: '1d',  interval: '5m'  },
+    '5d':  { range: '5d',  interval: '30m' },
+    '1mo': { range: '1mo', interval: '1d'  },
+    '3mo': { range: '3mo', interval: '1d'  },
+    '6mo': { range: '6mo', interval: '1wk' },
+    '1y':  { range: '1y',  interval: '1wk' },
+    '5y':  { range: '5y',  interval: '1mo' },
+  };
+  return map[period] || map['1mo'];
+}
+
+/* ── Load quote summary ── */
+async function loadQuote(symbol) {
+  try {
+    const url = yahooUrl(`chart/${symbol}?range=1d&interval=1d`);
+    const res  = await fetch(url);
+    const json = await res.json();
+    const data = JSON.parse(json.contents);
+    const meta = data?.chart?.result?.[0]?.meta;
+    if (!meta) throw new Error('no meta');
+
+    const price  = meta.regularMarketPrice ?? '--';
+    const prev   = meta.chartPreviousClose ?? meta.previousClose ?? price;
+    const change = price - prev;
+    const pct    = (change / prev) * 100;
+    const up     = change >= 0;
+
+    document.getElementById('stockName').textContent    = meta.longName || meta.shortName || symbol;
+    document.getElementById('stockSymbol').textContent  = symbol;
+    document.getElementById('stockPrice').textContent   = fmt(price, meta.currency);
+    const chEl = document.getElementById('priceChange');
+    chEl.textContent  = `${up ? '+' : ''}${fmt(change, meta.currency)} (${up ? '+' : ''}${pct.toFixed(2)}%)`;
+    chEl.className    = 'price-change ' + (up ? 'up' : 'down');
+
+    document.getElementById('infoOpen').textContent    = fmt(meta.regularMarketOpen, meta.currency);
+    document.getElementById('infoHigh').textContent    = fmt(meta.regularMarketDayHigh, meta.currency);
+    document.getElementById('infoLow').textContent     = fmt(meta.regularMarketDayLow, meta.currency);
+    document.getElementById('infoVolume').textContent  = fmtVol(meta.regularMarketVolume);
+    document.getElementById('info52High').textContent  = fmt(meta.fiftyTwoWeekHigh, meta.currency);
+    document.getElementById('info52Low').textContent   = fmt(meta.fiftyTwoWeekLow, meta.currency);
+  } catch (e) {
+    console.warn('loadQuote error', e);
+  }
+}
+
+/* ── Load chart data ── */
+async function loadChart(symbol, period) {
+  chartLoading.classList.add('show');
+  try {
+    const { range, interval } = periodToRange(period);
+    const url = yahooUrl(`chart/${symbol}?range=${range}&interval=${interval}`);
+    const res  = await fetch(url);
+    const json = await res.json();
+    const data = JSON.parse(json.contents);
+    const result = data?.chart?.result?.[0];
+    if (!result) throw new Error('no result');
+
+    const timestamps = result.timestamp ?? [];
+    const ohlcv       = result.indicators?.quote?.[0] ?? {};
+    const closes      = ohlcv.close ?? [];
+    const opens       = ohlcv.open  ?? [];
+    const highs       = ohlcv.high  ?? [];
+    const lows        = ohlcv.low   ?? [];
+
+    const points = timestamps
+      .map((t, i) => ({
+        x: new Date(t * 1000),
+        o: opens[i],
+        h: highs[i],
+        l: lows[i],
+        c: closes[i],
+      }))
+      .filter(p => p.c != null);
+
+    renderChart(points, period, symbol);
+  } catch (e) {
+    console.warn('loadChart error', e);
+    showToast('無法載入圖表資料，請確認股票代號是否正確。');
+  } finally {
+    chartLoading.classList.remove('show');
+  }
+}
+
+/* ── Render chart ── */
+function renderChart(points, period, symbol) {
+  const canvas = document.getElementById('stockChart');
+  if (chartInstance) { chartInstance.destroy(); chartInstance = null; }
+
+  const isLine = currentType === 'line';
+  const first  = points[0]?.c ?? 0;
+  const last   = points[points.length - 1]?.c ?? 0;
+  const up     = last >= first;
+  const color  = up ? '#3fb950' : '#f85149';
+
+  const timeUnit = ['1d','5d'].includes(period) ? 'hour'
+                 : ['1mo','3mo'].includes(period) ? 'day'
+                 : ['6mo','1y'].includes(period) ? 'week'
+                 : 'month';
+
+  const datasets = isLine
+    ? [{
+        label: symbol,
+        data: points.map(p => ({ x: p.x, y: p.c })),
+        borderColor: color,
+        backgroundColor: hexAlpha(color, .12),
+        borderWidth: 2,
+        pointRadius: 0,
+        fill: true,
+        tension: 0.3,
+        type: 'line',
+      }]
+    : [{
+        label: symbol,
+        data: points.map(p => ({ x: p.x, o: p.o, h: p.h, l: p.l, c: p.c })),
+        borderColor: ctx => {
+          const raw = ctx.raw;
+          if (!raw) return '#8b949e';
+          return raw.c >= raw.o ? '#3fb950' : '#f85149';
+        },
+        backgroundColor: ctx => {
+          const raw = ctx.raw;
+          if (!raw) return '#8b949e';
+          return raw.c >= raw.o ? hexAlpha('#3fb950', .7) : hexAlpha('#f85149', .7);
+        },
+        borderWidth: 1,
+        type: 'candlestick',
+      }];
+
+  /* Fall back to line if candlestick plugin not available */
+  const type = (isLine || !Chart.registry.controllers.candlestick) ? 'line' : 'candlestick';
+  if (!isLine && type === 'line') {
+    datasets[0] = {
+      label: symbol,
+      data: points.map(p => ({ x: p.x, y: p.c })),
+      borderColor: color,
+      backgroundColor: hexAlpha(color, .12),
+      borderWidth: 2,
+      pointRadius: 0,
+      fill: true,
+      tension: 0.3,
+    };
+  }
+
+  chartInstance = new Chart(canvas, {
+    type: 'line',
+    data: { datasets },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      interaction: { mode: 'index', intersect: false },
+      plugins: {
+        legend: { display: false },
+        tooltip: {
+          backgroundColor: '#21262d',
+          borderColor: '#30363d',
+          borderWidth: 1,
+          titleColor: '#8b949e',
+          bodyColor: '#e6edf3',
+          callbacks: {
+            label: ctx => {
+              const v = ctx.parsed.y;
+              return v != null ? ` ${v.toFixed(2)}` : '';
+            },
+          },
+        },
+      },
+      scales: {
+        x: {
+          type: 'time',
+          time: { unit: timeUnit },
+          grid: { color: '#21262d' },
+          ticks: { color: '#8b949e', maxTicksLimit: 8 },
+        },
+        y: {
+          position: 'right',
+          grid: { color: '#21262d' },
+          ticks: { color: '#8b949e' },
+        },
+      },
+    },
+  });
+}
+
+/* ── Watchlist ── */
+let watchlist = JSON.parse(localStorage.getItem('watchlist') || '[]');
+
+addWatchBtn.addEventListener('click', () => {
+  if (!currentSymbol) return;
+  if (watchlist.includes(currentSymbol)) {
+    showToast(`${currentSymbol} 已在自選清單中`);
+    return;
+  }
+  watchlist.push(currentSymbol);
+  saveWatchlist();
+  renderWatchlist();
+  showToast(`已加入 ${currentSymbol}`);
+});
+
+function saveWatchlist() {
+  localStorage.setItem('watchlist', JSON.stringify(watchlist));
+}
+
+function removeFromWatchlist(symbol) {
+  watchlist = watchlist.filter(s => s !== symbol);
+  saveWatchlist();
+  renderWatchlist();
+  showToast(`已移除 ${symbol}`);
+}
+
+async function renderWatchlist() {
+  if (watchlist.length === 0) {
+    watchGrid.innerHTML = '<p class="empty-hint">尚無自選股票，搜尋後點擊「加入自選」新增。</p>';
+    return;
+  }
+  watchGrid.innerHTML = watchlist.map(s => `
+    <div class="watch-card" data-symbol="${s}">
+      <button class="watch-remove" data-sym="${s}" title="移除">✕</button>
+      <div class="watch-card-symbol">${s}</div>
+      <div class="watch-card-price" id="wp-${s}">載入中…</div>
+      <div class="watch-card-change" id="wc-${s}"></div>
+    </div>
+  `).join('');
+
+  document.querySelectorAll('.watch-card').forEach(card => {
+    card.addEventListener('click', e => {
+      if (e.target.classList.contains('watch-remove')) return;
+      search(card.dataset.symbol);
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+  });
+  document.querySelectorAll('.watch-remove').forEach(btn => {
+    btn.addEventListener('click', () => removeFromWatchlist(btn.dataset.sym));
+  });
+
+  /* fetch prices in parallel */
+  await Promise.all(watchlist.map(s => fetchWatchPrice(s)));
+}
+
+async function fetchWatchPrice(symbol) {
+  try {
+    const url  = yahooUrl(`chart/${symbol}?range=1d&interval=1d`);
+    const res  = await fetch(url);
+    const json = await res.json();
+    const meta = JSON.parse(json.contents)?.chart?.result?.[0]?.meta;
+    if (!meta) return;
+    const price  = meta.regularMarketPrice ?? 0;
+    const prev   = meta.chartPreviousClose ?? meta.previousClose ?? price;
+    const change = price - prev;
+    const pct    = (change / prev) * 100;
+    const up     = change >= 0;
+
+    const pe = document.getElementById(`wp-${symbol}`);
+    const ce = document.getElementById(`wc-${symbol}`);
+    if (pe) pe.textContent = fmt(price, meta.currency);
+    if (ce) {
+      ce.textContent  = `${up ? '+' : ''}${change.toFixed(2)} (${up ? '+' : ''}${pct.toFixed(2)}%)`;
+      ce.className    = 'watch-card-change ' + (up ? 'up' : 'down');
+    }
+  } catch (_) {}
+}
+
+/* ── Utils ── */
+function fmt(val, currency) {
+  if (val == null || isNaN(val)) return '--';
+  const sym = currency === 'TWD' ? 'NT$'
+            : currency === 'USD' ? '$'
+            : (currency ? currency + ' ' : '');
+  return sym + Number(val).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+}
+
+function fmtVol(v) {
+  if (v == null) return '--';
+  if (v >= 1e9) return (v / 1e9).toFixed(2) + 'B';
+  if (v >= 1e6) return (v / 1e6).toFixed(2) + 'M';
+  if (v >= 1e3) return (v / 1e3).toFixed(1) + 'K';
+  return v.toString();
+}
+
+function hexAlpha(hex, a) {
+  const r = parseInt(hex.slice(1,3),16);
+  const g = parseInt(hex.slice(3,5),16);
+  const b = parseInt(hex.slice(5,7),16);
+  return `rgba(${r},${g},${b},${a})`;
+}
+
+let toastTimer;
+function showToast(msg) {
+  toastEl.textContent = msg;
+  toastEl.classList.add('show');
+  clearTimeout(toastTimer);
+  toastTimer = setTimeout(() => toastEl.classList.remove('show'), 2800);
+}
+
+/* ── Init ── */
+renderWatchlist();
+
+/* Auto-load AAPL on first visit */
+if (watchlist.length === 0) {
+  search('AAPL');
+}

--- a/stock-chart-website/js/app.js
+++ b/stock-chart-website/js/app.js
@@ -1,33 +1,73 @@
-/* ===================================================
+/* =====================================================
    Stock Chart App
-   Uses Yahoo Finance proxy via allorigins.win to
-   avoid CORS issues on GitHub Pages (static hosting).
-   Data is delayed / non-realtime — for reference only.
-   =================================================== */
+   - Multi-proxy fallback + timeout for reliability
+   - MA5 / MA20 / MA60 moving average overlays
+   - Market indices ticker bar
+   - Download chart as PNG
+   ===================================================== */
 
-const PROXY = 'https://api.allorigins.win/get?url=';
+// ── Proxy config ──────────────────────────────────────
+// Tried in order; each attempt aborted after 8 s
+const PROXIES = [
+  {
+    make: url => `https://corsproxy.io/?${encodeURIComponent(url)}`,
+    parse: res => res.json(),
+  },
+  {
+    make: url => `https://api.allorigins.win/get?url=${encodeURIComponent(url)}`,
+    parse: async res => { const j = await res.json(); return JSON.parse(j.contents); },
+  },
+  {
+    make: url => `https://api.codetabs.com/v1/proxy?quest=${encodeURIComponent(url)}`,
+    parse: res => res.json(),
+  },
+];
 
-/* ── DOM refs ── */
-const symbolInput   = document.getElementById('symbolInput');
-const searchBtn     = document.getElementById('searchBtn');
-const stockInfo     = document.getElementById('stockInfo');
-const chartSection  = document.getElementById('chartSection');
-const chartLoading  = document.getElementById('chartLoading');
-const addWatchBtn   = document.getElementById('addToWatchlist');
-const watchGrid     = document.getElementById('watchlistGrid');
-const toastEl       = document.getElementById('toast');
+async function yahooFetch(endpoint, timeoutMs = 8000) {
+  const base = 'https://query1.finance.yahoo.com/v8/finance/' + endpoint;
+  let lastErr;
+  for (const proxy of PROXIES) {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+    try {
+      const res = await fetch(proxy.make(base), { signal: ctrl.signal });
+      clearTimeout(timer);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await proxy.parse(res);
+      if (data?.chart?.error) throw new Error(data.chart.error.description || 'Yahoo error');
+      return data;
+    } catch (e) {
+      clearTimeout(timer);
+      lastErr = e;
+    }
+  }
+  throw lastErr || new Error('All proxies failed');
+}
 
-let chartInstance   = null;
-let currentSymbol   = '';
-let currentPeriod   = '1mo';
-let currentType     = 'line';
+// ── DOM refs ──────────────────────────────────────────
+const symbolInput  = document.getElementById('symbolInput');
+const searchBtn    = document.getElementById('searchBtn');
+const stockInfo    = document.getElementById('stockInfo');
+const chartSection = document.getElementById('chartSection');
+const chartLoading = document.getElementById('chartLoading');
+const chartError   = document.getElementById('chartError');
+const addWatchBtn  = document.getElementById('addToWatchlist');
+const watchGrid    = document.getElementById('watchlistGrid');
+const toastEl      = document.getElementById('toast');
 
-/* ── Quick picks ── */
+// ── State ──────────────────────────────────────────────
+let chartInstance = null;
+let currentSymbol = '';
+let currentPeriod = '1mo';
+let currentPoints = [];
+const maEnabled   = { 5: false, 20: false, 60: false };
+
+// ── Quick picks ───────────────────────────────────────
 document.querySelectorAll('.quick-btn').forEach(btn => {
   btn.addEventListener('click', () => search(btn.dataset.symbol));
 });
 
-/* ── Period buttons ── */
+// ── Period buttons ────────────────────────────────────
 document.querySelectorAll('.period-btn').forEach(btn => {
   btn.addEventListener('click', () => {
     document.querySelectorAll('.period-btn').forEach(b => b.classList.remove('active'));
@@ -37,17 +77,25 @@ document.querySelectorAll('.period-btn').forEach(btn => {
   });
 });
 
-/* ── Chart type buttons ── */
-document.querySelectorAll('.type-btn').forEach(btn => {
+// ── MA buttons ────────────────────────────────────────
+document.querySelectorAll('.ma-btn').forEach(btn => {
   btn.addEventListener('click', () => {
-    document.querySelectorAll('.type-btn').forEach(b => b.classList.remove('active'));
-    btn.classList.add('active');
-    currentType = btn.dataset.type;
-    if (currentSymbol) loadChart(currentSymbol, currentPeriod);
+    const p = Number(btn.dataset.ma);
+    maEnabled[p] = !maEnabled[p];
+    btn.classList.toggle('active', maEnabled[p]);
+    if (currentPoints.length) renderChart(currentPoints, currentPeriod, currentSymbol);
   });
 });
 
-/* ── Search ── */
+// ── Download button ───────────────────────────────────
+document.getElementById('downloadChart').addEventListener('click', downloadChart);
+
+// ── Retry button ──────────────────────────────────────
+document.getElementById('retryBtn').addEventListener('click', () => {
+  if (currentSymbol) loadChart(currentSymbol, currentPeriod);
+});
+
+// ── Search ────────────────────────────────────────────
 searchBtn.addEventListener('click', () => search(symbolInput.value.trim()));
 symbolInput.addEventListener('keydown', e => {
   if (e.key === 'Enter') search(symbolInput.value.trim());
@@ -57,168 +105,161 @@ async function search(symbol) {
   if (!symbol) return;
   symbol = symbol.toUpperCase();
   symbolInput.value = symbol;
-  currentSymbol = symbol;
+  currentSymbol     = symbol;
+  currentPoints     = [];
 
-  stockInfo.style.display = 'none';
+  stockInfo.style.display  = 'none';
   chartSection.style.display = 'none';
-  addWatchBtn.style.display = 'none';
+  addWatchBtn.style.display  = 'none';
 
-  await Promise.all([loadQuote(symbol), loadChart(symbol, currentPeriod)]);
+  searchBtn.disabled    = true;
+  searchBtn.textContent = '查詢中…';
 
-  stockInfo.style.display = '';
-  chartSection.style.display = '';
-  addWatchBtn.style.display = '';
+  try {
+    await Promise.all([loadQuote(symbol), loadChart(symbol, currentPeriod)]);
+    stockInfo.style.display    = '';
+    chartSection.style.display = '';
+    addWatchBtn.style.display  = '';
+  } finally {
+    searchBtn.disabled    = false;
+    searchBtn.textContent = '查詢';
+  }
 }
 
-/* ── Yahoo Finance helpers ── */
-function yahooUrl(endpoint) {
-  return PROXY + encodeURIComponent('https://query1.finance.yahoo.com/v8/finance/' + endpoint);
-}
-
-function periodToRange(period) {
-  const map = {
-    '1d':  { range: '1d',  interval: '5m'  },
-    '5d':  { range: '5d',  interval: '30m' },
-    '1mo': { range: '1mo', interval: '1d'  },
-    '3mo': { range: '3mo', interval: '1d'  },
-    '6mo': { range: '6mo', interval: '1wk' },
-    '1y':  { range: '1y',  interval: '1wk' },
-    '5y':  { range: '5y',  interval: '1mo' },
-  };
-  return map[period] || map['1mo'];
-}
-
-/* ── Load quote summary ── */
+// ── Quote ─────────────────────────────────────────────
 async function loadQuote(symbol) {
   try {
-    const url = yahooUrl(`chart/${symbol}?range=1d&interval=1d`);
-    const res  = await fetch(url);
-    const json = await res.json();
-    const data = JSON.parse(json.contents);
+    const data = await yahooFetch(`chart/${symbol}?range=1d&interval=1d`);
     const meta = data?.chart?.result?.[0]?.meta;
     if (!meta) throw new Error('no meta');
 
-    const price  = meta.regularMarketPrice ?? '--';
+    const price  = meta.regularMarketPrice ?? 0;
     const prev   = meta.chartPreviousClose ?? meta.previousClose ?? price;
     const change = price - prev;
-    const pct    = (change / prev) * 100;
+    const pct    = prev ? (change / prev) * 100 : 0;
     const up     = change >= 0;
 
-    document.getElementById('stockName').textContent    = meta.longName || meta.shortName || symbol;
-    document.getElementById('stockSymbol').textContent  = symbol;
-    document.getElementById('stockPrice').textContent   = fmt(price, meta.currency);
-    const chEl = document.getElementById('priceChange');
-    chEl.textContent  = `${up ? '+' : ''}${fmt(change, meta.currency)} (${up ? '+' : ''}${pct.toFixed(2)}%)`;
-    chEl.className    = 'price-change ' + (up ? 'up' : 'down');
+    document.getElementById('stockName').textContent   = meta.longName || meta.shortName || symbol;
+    document.getElementById('stockSymbol').textContent = symbol;
+    document.getElementById('stockPrice').textContent  = fmt(price, meta.currency);
 
-    document.getElementById('infoOpen').textContent    = fmt(meta.regularMarketOpen, meta.currency);
-    document.getElementById('infoHigh').textContent    = fmt(meta.regularMarketDayHigh, meta.currency);
-    document.getElementById('infoLow').textContent     = fmt(meta.regularMarketDayLow, meta.currency);
-    document.getElementById('infoVolume').textContent  = fmtVol(meta.regularMarketVolume);
-    document.getElementById('info52High').textContent  = fmt(meta.fiftyTwoWeekHigh, meta.currency);
-    document.getElementById('info52Low').textContent   = fmt(meta.fiftyTwoWeekLow, meta.currency);
+    const chEl = document.getElementById('priceChange');
+    chEl.textContent = `${up ? '+' : ''}${fmt(change, meta.currency)} (${up ? '+' : ''}${pct.toFixed(2)}%)`;
+    chEl.className   = 'price-change ' + (up ? 'up' : 'down');
+
+    document.getElementById('infoOpen').textContent   = fmt(meta.regularMarketOpen,    meta.currency);
+    document.getElementById('infoHigh').textContent   = fmt(meta.regularMarketDayHigh, meta.currency);
+    document.getElementById('infoLow').textContent    = fmt(meta.regularMarketDayLow,  meta.currency);
+    document.getElementById('infoVolume').textContent = fmtVol(meta.regularMarketVolume);
+    document.getElementById('info52High').textContent = fmt(meta.fiftyTwoWeekHigh,     meta.currency);
+    document.getElementById('info52Low').textContent  = fmt(meta.fiftyTwoWeekLow,      meta.currency);
   } catch (e) {
     console.warn('loadQuote error', e);
   }
 }
 
-/* ── Load chart data ── */
+// ── Chart data ────────────────────────────────────────
+const PERIOD_MAP = {
+  '1d':  { range: '1d',  interval: '5m'  },
+  '5d':  { range: '5d',  interval: '30m' },
+  '1mo': { range: '1mo', interval: '1d'  },
+  '3mo': { range: '3mo', interval: '1d'  },
+  '6mo': { range: '6mo', interval: '1wk' },
+  '1y':  { range: '1y',  interval: '1wk' },
+  '5y':  { range: '5y',  interval: '1mo' },
+};
+
 async function loadChart(symbol, period) {
   chartLoading.classList.add('show');
+  chartError.style.display = 'none';
   try {
-    const { range, interval } = periodToRange(period);
-    const url = yahooUrl(`chart/${symbol}?range=${range}&interval=${interval}`);
-    const res  = await fetch(url);
-    const json = await res.json();
-    const data = JSON.parse(json.contents);
+    const { range, interval } = PERIOD_MAP[period] ?? PERIOD_MAP['1mo'];
+    const data   = await yahooFetch(`chart/${symbol}?range=${range}&interval=${interval}`);
     const result = data?.chart?.result?.[0];
     if (!result) throw new Error('no result');
 
-    const timestamps = result.timestamp ?? [];
-    const ohlcv       = result.indicators?.quote?.[0] ?? {};
-    const closes      = ohlcv.close ?? [];
-    const opens       = ohlcv.open  ?? [];
-    const highs       = ohlcv.high  ?? [];
-    const lows        = ohlcv.low   ?? [];
+    const ts = result.timestamp ?? [];
+    const q  = result.indicators?.quote?.[0] ?? {};
 
-    const points = timestamps
+    const points = ts
       .map((t, i) => ({
         x: new Date(t * 1000),
-        o: opens[i],
-        h: highs[i],
-        l: lows[i],
-        c: closes[i],
+        o: q.open?.[i],
+        h: q.high?.[i],
+        l: q.low?.[i],
+        c: q.close?.[i],
       }))
       .filter(p => p.c != null);
 
+    if (!points.length) throw new Error('empty data');
+    currentPoints = points;
     renderChart(points, period, symbol);
   } catch (e) {
     console.warn('loadChart error', e);
-    showToast('無法載入圖表資料，請確認股票代號是否正確。');
+    chartError.style.display = '';
   } finally {
     chartLoading.classList.remove('show');
   }
 }
 
-/* ── Render chart ── */
+// ── Moving averages ───────────────────────────────────
+function calcMA(points, period) {
+  return points.map((p, i) => {
+    if (i < period - 1) return { x: p.x, y: null };
+    let sum = 0;
+    for (let j = i - period + 1; j <= i; j++) sum += points[j].c;
+    return { x: p.x, y: +(sum / period).toFixed(4) };
+  });
+}
+
+const MA_CONFIG = [
+  { period: 5,  color: '#f0883e', label: 'MA5'  },
+  { period: 20, color: '#79c0ff', label: 'MA20' },
+  { period: 60, color: '#bc8cff', label: 'MA60' },
+];
+
+// ── Render chart ──────────────────────────────────────
 function renderChart(points, period, symbol) {
   const canvas = document.getElementById('stockChart');
   if (chartInstance) { chartInstance.destroy(); chartInstance = null; }
 
-  const isLine = currentType === 'line';
-  const first  = points[0]?.c ?? 0;
-  const last   = points[points.length - 1]?.c ?? 0;
-  const up     = last >= first;
-  const color  = up ? '#3fb950' : '#f85149';
+  const first = points[0]?.c ?? 0;
+  const last  = points[points.length - 1]?.c ?? 0;
+  const up    = last >= first;
+  const color = up ? '#3fb950' : '#f85149';
 
-  const timeUnit = ['1d','5d'].includes(period) ? 'hour'
-                 : ['1mo','3mo'].includes(period) ? 'day'
-                 : ['6mo','1y'].includes(period) ? 'week'
-                 : 'month';
+  const timeUnit = ['1d','5d'].includes(period)     ? 'hour'
+                 : ['1mo','3mo'].includes(period)    ? 'day'
+                 : ['6mo','1y'].includes(period)     ? 'week' : 'month';
 
-  const datasets = isLine
-    ? [{
-        label: symbol,
-        data: points.map(p => ({ x: p.x, y: p.c })),
-        borderColor: color,
-        backgroundColor: hexAlpha(color, .12),
-        borderWidth: 2,
-        pointRadius: 0,
-        fill: true,
-        tension: 0.3,
-        type: 'line',
-      }]
-    : [{
-        label: symbol,
-        data: points.map(p => ({ x: p.x, o: p.o, h: p.h, l: p.l, c: p.c })),
-        borderColor: ctx => {
-          const raw = ctx.raw;
-          if (!raw) return '#8b949e';
-          return raw.c >= raw.o ? '#3fb950' : '#f85149';
-        },
-        backgroundColor: ctx => {
-          const raw = ctx.raw;
-          if (!raw) return '#8b949e';
-          return raw.c >= raw.o ? hexAlpha('#3fb950', .7) : hexAlpha('#f85149', .7);
-        },
-        borderWidth: 1,
-        type: 'candlestick',
-      }];
+  const datasets = [{
+    label: symbol,
+    data: points.map(p => ({ x: p.x, y: p.c })),
+    borderColor: color,
+    backgroundColor: hexAlpha(color, .1),
+    borderWidth: 2,
+    pointRadius: 0,
+    fill: true,
+    tension: 0.3,
+    order: 10,
+  }];
 
-  /* Fall back to line if candlestick plugin not available */
-  const type = (isLine || !Chart.registry.controllers.candlestick) ? 'line' : 'candlestick';
-  if (!isLine && type === 'line') {
-    datasets[0] = {
-      label: symbol,
-      data: points.map(p => ({ x: p.x, y: p.c })),
-      borderColor: color,
-      backgroundColor: hexAlpha(color, .12),
-      borderWidth: 2,
+  for (const ma of MA_CONFIG) {
+    if (!maEnabled[ma.period]) continue;
+    datasets.push({
+      label: ma.label,
+      data: calcMA(points, ma.period),
+      borderColor: ma.color,
+      borderWidth: 1.5,
       pointRadius: 0,
-      fill: true,
+      fill: false,
       tension: 0.3,
-    };
+      spanGaps: false,
+      order: 1,
+    });
   }
+
+  const hasMA = datasets.length > 1;
 
   chartInstance = new Chart(canvas, {
     type: 'line',
@@ -228,17 +269,21 @@ function renderChart(points, period, symbol) {
       maintainAspectRatio: false,
       interaction: { mode: 'index', intersect: false },
       plugins: {
-        legend: { display: false },
+        legend: {
+          display: hasMA,
+          labels: { color: '#8b949e', boxWidth: 18, padding: 12, font: { size: 12 } },
+        },
         tooltip: {
           backgroundColor: '#21262d',
           borderColor: '#30363d',
           borderWidth: 1,
           titleColor: '#8b949e',
           bodyColor: '#e6edf3',
+          padding: 10,
           callbacks: {
             label: ctx => {
               const v = ctx.parsed.y;
-              return v != null ? ` ${v.toFixed(2)}` : '';
+              return v != null ? ` ${ctx.dataset.label}: ${v.toFixed(2)}` : '';
             },
           },
         },
@@ -260,34 +305,102 @@ function renderChart(points, period, symbol) {
   });
 }
 
-/* ── Watchlist ── */
+// ── Download chart ────────────────────────────────────
+function downloadChart() {
+  if (!chartInstance) return;
+  const src = chartInstance.canvas;
+  const off = document.createElement('canvas');
+  off.width  = src.width;
+  off.height = src.height;
+  const ctx = off.getContext('2d');
+  ctx.fillStyle = '#161b22';
+  ctx.fillRect(0, 0, off.width, off.height);
+  ctx.drawImage(src, 0, 0);
+  const a = document.createElement('a');
+  a.download = `${currentSymbol || 'chart'}_${currentPeriod}.png`;
+  a.href = off.toDataURL('image/png');
+  a.click();
+}
+
+// ── Market ticker ─────────────────────────────────────
+const TICKER_SYMBOLS = [
+  { sym: '^GSPC',  name: 'S&P 500'  },
+  { sym: '^IXIC',  name: 'NASDAQ'   },
+  { sym: '^DJI',   name: '道瓊斯'   },
+  { sym: '^TWII',  name: '台灣加權' },
+  { sym: '^HSI',   name: '恆生'     },
+  { sym: 'GC=F',   name: '黃金'     },
+  { sym: 'CL=F',   name: '原油'     },
+];
+
+function tickId(sym) { return 'tick_' + sym.replace(/[^a-z0-9]/gi, '_'); }
+
+async function loadMarketTicker() {
+  const bar = document.getElementById('tickerInner');
+  if (!bar) return;
+
+  bar.innerHTML = TICKER_SYMBOLS.map(({ sym, name }) => `
+    <div class="ticker-item" id="${tickId(sym)}" data-symbol="${sym}">
+      <span class="ticker-name">${name}</span>
+      <span class="ticker-price">--</span>
+      <span class="ticker-change">--</span>
+    </div>
+  `).join('');
+
+  bar.querySelectorAll('.ticker-item').forEach(item => {
+    item.addEventListener('click', () => {
+      search(item.dataset.symbol);
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+  });
+
+  await Promise.all(TICKER_SYMBOLS.map(({ sym }) => fetchTickerPrice(sym)));
+}
+
+async function fetchTickerPrice(sym) {
+  const el = document.getElementById(tickId(sym));
+  if (!el) return;
+  try {
+    const data = await yahooFetch(`chart/${sym}?range=1d&interval=1d`, 10000);
+    const meta = data?.chart?.result?.[0]?.meta;
+    if (!meta) return;
+    const price  = meta.regularMarketPrice ?? 0;
+    const prev   = meta.chartPreviousClose ?? meta.previousClose ?? price;
+    const change = price - prev;
+    const pct    = prev ? (change / prev) * 100 : 0;
+    const up     = change >= 0;
+    el.querySelector('.ticker-price').textContent = price.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+    const chEl = el.querySelector('.ticker-change');
+    chEl.textContent = `${up ? '+' : ''}${pct.toFixed(2)}%`;
+    chEl.className   = 'ticker-change ' + (up ? 'up' : 'down');
+  } catch (_) {
+    el.querySelector('.ticker-price').textContent = '--';
+  }
+}
+
+// ── Watchlist ─────────────────────────────────────────
 let watchlist = JSON.parse(localStorage.getItem('watchlist') || '[]');
 
 addWatchBtn.addEventListener('click', () => {
   if (!currentSymbol) return;
-  if (watchlist.includes(currentSymbol)) {
-    showToast(`${currentSymbol} 已在自選清單中`);
-    return;
-  }
+  if (watchlist.includes(currentSymbol)) { showToast(`${currentSymbol} 已在自選清單中`); return; }
   watchlist.push(currentSymbol);
   saveWatchlist();
   renderWatchlist();
   showToast(`已加入 ${currentSymbol}`);
 });
 
-function saveWatchlist() {
-  localStorage.setItem('watchlist', JSON.stringify(watchlist));
-}
+function saveWatchlist() { localStorage.setItem('watchlist', JSON.stringify(watchlist)); }
 
-function removeFromWatchlist(symbol) {
-  watchlist = watchlist.filter(s => s !== symbol);
+function removeFromWatchlist(sym) {
+  watchlist = watchlist.filter(s => s !== sym);
   saveWatchlist();
   renderWatchlist();
-  showToast(`已移除 ${symbol}`);
+  showToast(`已移除 ${sym}`);
 }
 
 async function renderWatchlist() {
-  if (watchlist.length === 0) {
+  if (!watchlist.length) {
     watchGrid.innerHTML = '<p class="empty-hint">尚無自選股票，搜尋後點擊「加入自選」新增。</p>';
     return;
   }
@@ -300,45 +413,41 @@ async function renderWatchlist() {
     </div>
   `).join('');
 
-  document.querySelectorAll('.watch-card').forEach(card => {
+  watchGrid.querySelectorAll('.watch-card').forEach(card => {
     card.addEventListener('click', e => {
       if (e.target.classList.contains('watch-remove')) return;
       search(card.dataset.symbol);
       window.scrollTo({ top: 0, behavior: 'smooth' });
     });
   });
-  document.querySelectorAll('.watch-remove').forEach(btn => {
+  watchGrid.querySelectorAll('.watch-remove').forEach(btn => {
     btn.addEventListener('click', () => removeFromWatchlist(btn.dataset.sym));
   });
 
-  /* fetch prices in parallel */
   await Promise.all(watchlist.map(s => fetchWatchPrice(s)));
 }
 
-async function fetchWatchPrice(symbol) {
+async function fetchWatchPrice(sym) {
   try {
-    const url  = yahooUrl(`chart/${symbol}?range=1d&interval=1d`);
-    const res  = await fetch(url);
-    const json = await res.json();
-    const meta = JSON.parse(json.contents)?.chart?.result?.[0]?.meta;
+    const data = await yahooFetch(`chart/${sym}?range=1d&interval=1d`);
+    const meta = data?.chart?.result?.[0]?.meta;
     if (!meta) return;
     const price  = meta.regularMarketPrice ?? 0;
     const prev   = meta.chartPreviousClose ?? meta.previousClose ?? price;
     const change = price - prev;
-    const pct    = (change / prev) * 100;
+    const pct    = prev ? (change / prev) * 100 : 0;
     const up     = change >= 0;
-
-    const pe = document.getElementById(`wp-${symbol}`);
-    const ce = document.getElementById(`wc-${symbol}`);
+    const pe = document.getElementById(`wp-${sym}`);
+    const ce = document.getElementById(`wc-${sym}`);
     if (pe) pe.textContent = fmt(price, meta.currency);
     if (ce) {
-      ce.textContent  = `${up ? '+' : ''}${change.toFixed(2)} (${up ? '+' : ''}${pct.toFixed(2)}%)`;
-      ce.className    = 'watch-card-change ' + (up ? 'up' : 'down');
+      ce.textContent = `${up ? '+' : ''}${change.toFixed(2)} (${up ? '+' : ''}${pct.toFixed(2)}%)`;
+      ce.className   = 'watch-card-change ' + (up ? 'up' : 'down');
     }
   } catch (_) {}
 }
 
-/* ── Utils ── */
+// ── Utils ──────────────────────────────────────────────
 function fmt(val, currency) {
   if (val == null || isNaN(val)) return '--';
   const sym = currency === 'TWD' ? 'NT$'
@@ -356,9 +465,9 @@ function fmtVol(v) {
 }
 
 function hexAlpha(hex, a) {
-  const r = parseInt(hex.slice(1,3),16);
-  const g = parseInt(hex.slice(3,5),16);
-  const b = parseInt(hex.slice(5,7),16);
+  const r = parseInt(hex.slice(1,3), 16);
+  const g = parseInt(hex.slice(3,5), 16);
+  const b = parseInt(hex.slice(5,7), 16);
   return `rgba(${r},${g},${b},${a})`;
 }
 
@@ -370,10 +479,7 @@ function showToast(msg) {
   toastTimer = setTimeout(() => toastEl.classList.remove('show'), 2800);
 }
 
-/* ── Init ── */
+// ── Init ───────────────────────────────────────────────
+loadMarketTicker();
 renderWatchlist();
-
-/* Auto-load AAPL on first visit */
-if (watchlist.length === 0) {
-  search('AAPL');
-}
+if (!watchlist.length) search('AAPL');


### PR DESCRIPTION
- Dark-themed single-page stock chart app (HTML/CSS/JS)
- Fetches Yahoo Finance data via allorigins proxy (no API key needed)
- Line chart with Chart.js; period selector (1D–5Y)
- Quick-pick buttons for popular US/TW stocks
- LocalStorage watchlist with live price refresh
- GitHub Actions workflow to deploy stock-chart-website/ to GitHub Pages

https://claude.ai/code/session_01UzLGFaiMcQcwmU4fBm551B